### PR TITLE
Add op_fclose to keep fclose's type signature the same

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -118,11 +118,17 @@ static opus_int64 op_ftell(void *_stream){
 #endif
 }
 
+static int op_fclose(void *_stream){
+  /*This indirection maintains fclose's type signature which is necessary for
+     Control Flow Integrity.*/
+  return fclose((FILE *)_stream);
+}
+
 static const OpusFileCallbacks OP_FILE_CALLBACKS={
   op_fread,
   op_fseek,
   op_ftell,
-  (op_close_func)fclose
+  op_fclose
 };
 
 #if defined(_WIN32)
@@ -257,7 +263,7 @@ static const OpusFileCallbacks OP_UNSEEKABLE_FILE_CALLBACKS={
   op_fread,
   op_fseek_fail,
   op_ftell,
-  (op_close_func)fclose
+  op_fclose
 };
 
 # define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
This problem cropped up when I was trying to enable CFI-icall with Opusfile as a dependency. CFI indirect function call sanitization checks that function signatures at runtime match those that were determined at compile time. This fix ensures that `fclose` has the correct function signature when being passed a stream.

I have a quick sample here on Godbolt: https://godbolt.org/z/EGsPYae51

An exit code of 132 is SIGILL which means a CFI violation was found and program execution was stopped. 