### PR TITLE
Use existing targets for libogg and libopus if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,12 @@ option(OP_DISABLE_DOCS "Do not build API documentation" OFF)
 
 include(GNUInstallDirs)
 
-find_package(Ogg REQUIRED)
-find_package(Opus REQUIRED)
+if (NOT TARGET Ogg::ogg)
+  find_package(Ogg REQUIRED)
+endif()
+if(NOT TARGET Opus::opus)
+  find_package(Opus REQUIRED)
+endif()
 
 include(CMakePushCheckState)
 include(CheckSymbolExists)


### PR DESCRIPTION
This is useful when building opusfile as a subproject.