### PR TITLE
http: Avoid undefined behavior in va_arg conversion

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -3466,10 +3466,12 @@ static void *op_url_stream_vcreate_impl(OpusFileCallbacks *_cb,
   pinfo=NULL;
   *_pinfo=NULL;
   for(;;){
-    ptrdiff_t request;
-    request=va_arg(_ap,char *)-(char *)NULL;
+    char *prequest;
+    intptr_t request;
+    prequest=va_arg(_ap,char *);
     /*If we hit NULL, we're done processing options.*/
-    if(!request)break;
+    if(!prequest)break;
+    request=(intptr_t)prequest;
     switch(request){
       case OP_SSL_SKIP_CERTIFICATE_CHECK_REQUEST:{
         skip_certificate_check=!!va_arg(_ap,opus_int32);


### PR DESCRIPTION
Compiling under Clang 13 with -Wextra resulted in the following warning:

```
src/http.c:3470:31: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
    request=va_arg(_ap,char *)-(char *)NULL;
```

It seems subtracting a null pointer is undefined behavior, which we can avoid by casting to intptr_t instead.

Request macros (e.g. OP_GET_SERVER_INFO) already do a simple cast `((char*)_request)` rather than addition with null pointer `(_request+(char*)NULL)` so nothing needs to be changed on that end.