### PR TITLE
Generate pkg-config files under CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,17 @@ endif()
 check_symbol_exists(lrintf "math.h" OP_HAVE_LRINTF)
 cmake_pop_check_state()
 
+# Helper function to configure pkg-config files
+function(configure_pkg_config_file pkg_config_file_in)
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    set(exec_prefix ${CMAKE_INSTALL_FULL_BINDIR})
+    set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+    set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+    set(VERSION ${PROJECT_VERSION})
+    string(REPLACE ".in" "" pkg_config_file ${pkg_config_file_in})
+    configure_file(${pkg_config_file_in} ${pkg_config_file} @ONLY)
+endfunction()
+
 add_library(opusfile
   "${CMAKE_CURRENT_SOURCE_DIR}/include/opusfile.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/info.c"
@@ -83,6 +94,10 @@ target_compile_definitions(opusfile
     $<$<BOOL:${OP_ENABLE_ASSERTIONS}>:OP_ENABLE_ASSERTIONS>
     $<$<BOOL:${OP_HAVE_LRINTF}>:OP_HAVE_LRINTF>
 )
+if(OP_HAVE_LIBM)
+  set(lrintf_lib "-lm")
+endif()
+configure_pkg_config_file(opusfile.pc.in)
 install(TARGETS opusfile
   EXPORT OpusFileTargets
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -90,6 +105,9 @@ install(TARGETS opusfile
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/opus"
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/opus"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/opusfile.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 if(NOT OP_DISABLE_HTTP)
@@ -177,6 +195,8 @@ if(NOT OP_DISABLE_HTTP)
       $<$<C_COMPILER_ID:Clang,GNU>:-Wno-long-long>
       $<$<C_COMPILER_ID:Clang,GNU>:-fvisibility=hidden>
   )
+  set(openssl "openssl")
+  configure_pkg_config_file(opusurl.pc.in)
   install(TARGETS opusurl
     EXPORT OpusFileTargets
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -184,6 +204,9 @@ if(NOT OP_DISABLE_HTTP)
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/opus"
     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/opus"
+  )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/opusurl.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 endif()
 


### PR DESCRIPTION
configure_pkg_config_file helper function copied from the ogg repository.

The generated .pc files have two differences (presumably minor) compared to autotools:
* Paths: Autotools outputs `exec_prefix=${prefix}`, `libdir=${exec_prefix}/lib`, etc. while the CMake output is expanded out (similar to what ogg does currently)
* Version string: Autotools outputs `0.12-38-gcf218fb-dirty` if a modified repository is detected, while CMake ignores this and outputs `0.12-38-gcf218fb`

opusfile.pc output:

```
# opusfile installed pkg-config file

prefix=/home/build/opus-git-optimized/prefix
exec_prefix=/home/build/opus-git-optimized/prefix/bin
libdir=/home/build/opus-git-optimized/prefix/lib64
includedir=/home/build/opus-git-optimized/prefix/include

Name: opusfile
Description: High-level Opus decoding library
Version: 0.12-38-gcf218fb
Requires.private: ogg >= 1.3 opus >= 1.0.1
Conflicts:
Libs: -L${libdir} -lopusfile
Libs.private: -lm
Cflags: -I${includedir}/opus
```

opusurl.pc output:
```
# opusurl installed pkg-config file

prefix=/home/build/opus-git-optimized/prefix
exec_prefix=/home/build/opus-git-optimized/prefix/bin
libdir=/home/build/opus-git-optimized/prefix/lib64
includedir=/home/build/opus-git-optimized/prefix/include

Name: opusurl
Description: High-level Opus decoding library, URL support
Version: 0.12-38-gcf218fb
Requires: opusfile
Requires.private: openssl
Conflicts:
Libs: -L${libdir} -lopusurl
```
