### PR TITLE
CMake: Fix target import on case-sensitive file systems

### DIFF
--- a/cmake/OpusFileConfig.cmake.in
+++ b/cmake/OpusFileConfig.cmake.in
@@ -47,6 +47,6 @@ if (NOT @OP_DISABLE_HTTP@)
 endif()
 
 # Including targets of opusfile
-include("${CMAKE_CURRENT_LIST_DIR}/opusfileTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/OpusFileTargets.cmake")
 
-check_required_components(opusfile)
+check_required_components(OpusFile)


### PR DESCRIPTION
On case-sensitive filesystems, `OpusFileConfig.cmake` fails to include the exported targets due to mismatched capitalisation.

In CMakeLists.txt:
```cmake
install(EXPORT OpusFileTargets
  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/opusfile"
  NAMESPACE OpusFile::
)
```

In `OpusFileConfig.cmake.in`:
```cmake
include("${CMAKE_CURRENT_LIST_DIR}/opusfileTargets.cmake")
```
