### PR TITLE
fix: remove need for explicit include path /usr/local/opus

### DIFF
--- a/include/opusfile.h
+++ b/include/opusfile.h
@@ -107,7 +107,7 @@ extern "C" {
 # include <stdarg.h>
 # include <stdio.h>
 # include <ogg/ogg.h>
-# include <opus_multistream.h>
+# include <opus/opus_multistream.h>
 
 /**@cond PRIVATE*/
 


### PR DESCRIPTION
This is not the way parent headers are supposed to be included. This has been an issue for years and nobody raised a PR yet, so i'm raising one.