### PR TITLE
Fix for android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ target_compile_options(opusfile
     $<$<C_COMPILER_ID:MSVC>:/wd4267>
     $<$<C_COMPILER_ID:MSVC>:/wd4244>
     $<$<C_COMPILER_ID:MSVC>:/wd4090>
-    $<$<C_COMPILER_ID:Clang,GNU>:-std=c89>
     $<$<C_COMPILER_ID:Clang,GNU>:-pedantic>
     $<$<C_COMPILER_ID:Clang,GNU>:-Wall>
     $<$<C_COMPILER_ID:Clang,GNU>:-Wextra>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,6 @@ target_compile_options(opusurl
     $<$<C_COMPILER_ID:MSVC>:/wd4267>
     $<$<C_COMPILER_ID:MSVC>:/wd4244>
     $<$<C_COMPILER_ID:MSVC>:/wd4090>
-    $<$<C_COMPILER_ID:Clang,GNU>:-std=c89>
     $<$<C_COMPILER_ID:Clang,GNU>:-pedantic>
     $<$<C_COMPILER_ID:Clang,GNU>:-Wall>
     $<$<C_COMPILER_ID:Clang,GNU>:-Wextra>
@@ -219,7 +218,6 @@ if(NOT OP_DISABLE_EXAMPLES)
       $<$<C_COMPILER_ID:MSVC>:/wd4267>
       $<$<C_COMPILER_ID:MSVC>:/wd4244>
       $<$<C_COMPILER_ID:MSVC>:/wd4090>
-      $<$<C_COMPILER_ID:Clang,GNU>:-std=c89>
       $<$<C_COMPILER_ID:Clang,GNU>:-pedantic>
       $<$<C_COMPILER_ID:Clang,GNU>:-Wall>
       $<$<C_COMPILER_ID:Clang,GNU>:-Wextra>
@@ -252,7 +250,6 @@ if(NOT OP_DISABLE_EXAMPLES)
       $<$<C_COMPILER_ID:MSVC>:/wd4267>
       $<$<C_COMPILER_ID:MSVC>:/wd4244>
       $<$<C_COMPILER_ID:MSVC>:/wd4090>
-      $<$<C_COMPILER_ID:Clang,GNU>:-std=c89>
       $<$<C_COMPILER_ID:Clang,GNU>:-pedantic>
       $<$<C_COMPILER_ID:Clang,GNU>:-Wall>
       $<$<C_COMPILER_ID:Clang,GNU>:-Wextra>


### PR DESCRIPTION
This removes overriding c89 standard, library consumers should decide which standard library should be built on